### PR TITLE
feat(monitoring): add routes about API monitoring

### DIFF
--- a/src/api/controller/__init__.py
+++ b/src/api/controller/__init__.py
@@ -1,2 +1,3 @@
 from .admin import *
 from .user import *
+from .monitoring import *

--- a/src/api/controller/monitoring/__init__.py
+++ b/src/api/controller/monitoring/__init__.py
@@ -1,0 +1,1 @@
+from .monitoring import *

--- a/src/api/controller/monitoring/monitoring.py
+++ b/src/api/controller/monitoring/monitoring.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, abort, request
 
 from database import establishing_connection
 
@@ -8,10 +8,26 @@ class MonitoringRoutes(Blueprint):
         super().__init__("monitoring", __name__,
                          url_prefix="/monitoring")
         
-        self.route("/liveness",
-                   methods=["GET"])(self.liveness_api)
+        self.route("/liveness")(self.liveness_api)
         self.route("/readiness",
                    methods=["GET"])(self.readiness_api)
 
     def liveness_api(self):
         return '', 204
+
+    def readiness_api(self) -> None:
+        try:
+            conn = establishing_connection()
+        except Exception:
+            abort(503)
+        rowcount: int
+        with conn.cursor() as curs:
+            curs.execute("SELECT 1;")
+            rowcount = curs.rowcount
+        conn.close()
+        
+        if rowcount != 1:
+            abort(503)
+
+        if request.method == "GET":
+            return '', 204

--- a/src/api/controller/monitoring/monitoring.py
+++ b/src/api/controller/monitoring/monitoring.py
@@ -8,7 +8,8 @@ class MonitoringRoutes(Blueprint):
         super().__init__("monitoring", __name__,
                          url_prefix="/monitoring")
         
-        self.route("/liveness")(self.liveness_api)
+        self.route("/liveness",
+                   methods=["GET"])(self.liveness_api)
         self.route("/readiness",
                    methods=["GET"])(self.readiness_api)
 

--- a/src/api/controller/monitoring/monitoring.py
+++ b/src/api/controller/monitoring/monitoring.py
@@ -1,0 +1,17 @@
+from flask import Blueprint
+
+from database import establishing_connection
+
+
+class MonitoringRoutes(Blueprint):
+    def __init__(self):
+        super().__init__("monitoring", __name__,
+                         url_prefix="/monitoring")
+        
+        self.route("/liveness",
+                   methods=["GET"])(self.liveness_api)
+        self.route("/readiness",
+                   methods=["GET"])(self.readiness_api)
+
+    def liveness_api(self):
+        return '', 204

--- a/src/main.py
+++ b/src/main.py
@@ -6,16 +6,16 @@ from flask import Flask
 from flask_cors import CORS
 
 from api.controller import (
-    AdminRoutes, 
+    AdminRoutes,
     AuthRoutes,
     MonitoringRoutes
 )
 from database.repositories import (
-    TokenRepositoryInterface, 
-    UserAdminRepositoryInterface, 
+    TokenRepositoryInterface,
+    UserAdminRepositoryInterface,
     LicenseRepositoryInterface,
     UserRepositoryInterface,
-    LicenseRepository, 
+    LicenseRepository,
     UserRepository,
     TokenRepository,
     UserAdminRepository,
@@ -45,26 +45,32 @@ class Api(object):
     def __init__(self) -> None:
         self.api = Flask("carmate-api" if not os.getenv("API_NAME") else os.getenv("API_NAME"))
         self.cors = CORS(self.api, resources={r"*": {"origins": "*"}})
-    
-        monitoring = MonitoringRoutes()
-        match os.getenv("API_MODE"):
-            case "PROD":
-                self.postgres()
-                self.api.before_request(monitoring.readiness_api)
-            case "TEST":
-                self.mock()
-            case None:
-                raise Exception("API_MODE must be set !")
-            case _:
-                raise Exception(f"Value error in API_MODE ({os.getenv('API_MODE')} invalid)")
 
         logging.basicConfig(format=self.logging_format,
                             datefmt='%d/%m/%Y %I:%M:%S %p',
                             level=self.logging_level)
 
+        match os.getenv("API_MODE"):
+            case "PROD":
+                self.postgres()
+            case "TEST":
+                self.mock()
+            case None:
+                raise Exception("API_MODE must be set !")
+            case _:
+                raise Exception(
+                    f"Value error in API_MODE ({os.getenv('API_MODE')} invalid)")
+
+        monitoring = MonitoringRoutes()
+        auth = AuthRoutes(self.user_repository, self.token_repository, self.license_repository)
+        admin = AdminRoutes(self.user_repository, self.user_admin_repository, self.token_repository, self.license_repository)
+        if os.getenv("API_MODE") == "PROD":
+            auth.before_request(monitoring.readiness_api)
+            admin.before_request(monitoring.readiness_api)
+
         self.api.register_blueprint(monitoring)
-        self.api.register_blueprint(AuthRoutes(self.user_repository, self.token_repository, self.license_repository))
-        self.api.register_blueprint(AdminRoutes(self.user_repository, self.user_admin_repository, self.token_repository, self.license_repository))
+        self.api.register_blueprint(auth)
+        self.api.register_blueprint(admin)
 
     def mock(self) -> None:
         self.user_repository = InMemoryUserRepository()

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from flask_cors import CORS
 from api.controller import (
     AdminRoutes, 
     AuthRoutes,
+    MonitoringRoutes
 )
 from database.repositories import (
     TokenRepositoryInterface, 
@@ -59,6 +60,7 @@ class Api(object):
         self.api = Flask("carmate-api" if not os.getenv("API_NAME") else os.getenv("API_NAME"))
         self.cors = CORS(self.api, resources={r"*": {"origins": "*"}})
 
+        self.api.register_blueprint(MonitoringRoutes())
         self.api.register_blueprint(AuthRoutes(self.user_repository, self.token_repository, self.license_repository))
         self.api.register_blueprint(AdminRoutes(self.user_repository, self.user_admin_repository, self.token_repository, self.license_repository))
 


### PR DESCRIPTION
Add routes:
- liveness
```
curl http://localhost:5000/monitoring/liveness
```
- readiness
```
curl http://localhost:5000/monitoring/readiness
```

When the API is `PROD` mode :
- Return `503` when the database is unavailable

I'll use `/monitoring/liveness` to my docker-compose in [carmate-repository](https://github.com/DUT-Info-Montreuil/SAE-5.A-carmate)
