### PR TITLE
refactor(repositories): remove try-except blocks on `establishing_connection` function

### DIFF
--- a/src/api/controller/user/profiles.py
+++ b/src/api/controller/user/profiles.py
@@ -152,6 +152,7 @@ class ProfilesRoutes(Blueprint):
             abort(404)
         except CredentialInvalid:
             abort(401)
-        except Exception:
+        except Exception as e:
+            print(e)
             abort(500)
         return jsonify({"driver_id": driver.id})

--- a/src/database/repositories/carpooling_repository.py
+++ b/src/database/repositories/carpooling_repository.py
@@ -1,6 +1,5 @@
 from abc import ABC
 from typing import List, Tuple
-from datetime import datetime
 
 from psycopg2 import ProgrammingError, errorcodes
 from psycopg2.errors import lookup
@@ -67,7 +66,6 @@ class CarpoolingRepository(CarpoolingRepositoryInterface):
                 except Exception as e:
                     raise InternalServer(str(e))
                 carpooling_id = curs.fetchone()
-
         return carpooling_id[0]
 
     def get_carpoolings_route(self,
@@ -79,35 +77,39 @@ class CarpoolingRepository(CarpoolingRepositoryInterface):
                               page: int = 1,
                               per_page: int = 10) -> Tuple[int, List[CarpoolingForRecap]] | Tuple[int, List]:
         query_nb_carpoolings_route = f"""
-                    SELECT count(id) as nb_carpoolings_route
-                    FROM carmate.{self.POSTGRES_TABLE_NAME}
-                    WHERE ABS(starting_point[1] - %s) < {self.RADIUS} 
-                        AND ABS(starting_point[2] - %s) < {self.RADIUS} 
-                        AND ABS(destination[1] - %s) < {self.RADIUS}
-                        AND ABS(destination[2] - %s) < {self.RADIUS}
-                        AND departure_date_time >= to_timestamp(%s)
+            SELECT count(id) as nb_carpoolings_route
+            FROM carmate.{self.POSTGRES_TABLE_NAME}
+            WHERE ABS(starting_point[1] - %s) < {self.RADIUS} 
+                AND ABS(starting_point[2] - %s) < {self.RADIUS} 
+                AND ABS(destination[1] - %s) < {self.RADIUS}
+                AND ABS(destination[2] - %s) < {self.RADIUS}
+                AND departure_date_time >= to_timestamp(%s)
         """
-        query = f"""SELECT c.id, c.starting_point, c.destination, c.max_passengers, c.price, c.departure_date_time, c.driver_id
-                    FROM carmate.{self.POSTGRES_TABLE_NAME} as c 
-                    LEFT JOIN carmate.{BookingCarpoolingRepository.POSTGRES_TABLE_NAME} as r on (c.id = r.carpooling_id)
-                    GROUP BY c.id
-                    HAVING ABS(starting_point[1] - %s) < {self.RADIUS} 
-                        AND ABS(starting_point[2] - %s) < {self.RADIUS} 
-                        AND ABS(destination[1] - %s) < {self.RADIUS}
-                        AND ABS(destination[2] - %s) < {self.RADIUS}
-                        AND departure_date_time >= to_timestamp(%s)
-                    ORDER BY c.id
-                    LIMIT {per_page} OFFSET {(page - 1) * per_page}"""
+        query = f"""
+            SELECT c.id, c.starting_point, c.destination, c.max_passengers, c.price, c.departure_date_time, c.driver_id
+            FROM carmate.{self.POSTGRES_TABLE_NAME} c 
+            LEFT JOIN carmate.{BookingCarpoolingRepository.POSTGRES_TABLE_NAME} r 
+                ON c.id=r.carpooling_id
+            GROUP BY c.id
+            HAVING ABS(starting_point[1] - %s) < {self.RADIUS} 
+                AND ABS(starting_point[2] - %s) < {self.RADIUS} 
+                AND ABS(destination[1] - %s) < {self.RADIUS}
+                AND ABS(destination[2] - %s) < {self.RADIUS}
+                AND departure_date_time >= to_timestamp(%s)
+            ORDER BY c.id
+            LIMIT {per_page} 
+            OFFSET {(page - 1) * per_page}
+        """
 
         nb_carpoolings_route: int = 0
-        carpoolings_data: List[tuple]
+        carpoolings_data: List[tuple] = []
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query_nb_carpoolings_route,
                                  (start_lat, start_lon, end_lat, end_lon, departure_date_time,))
                 except ProgrammingError:
-                    return nb_carpoolings_route, []
+                    return nb_carpoolings_route, carpoolings_data
                 except Exception as e:
                     raise InternalServer(str(e))
 
@@ -119,11 +121,10 @@ class CarpoolingRepository(CarpoolingRepositoryInterface):
                 try:
                     curs.execute(query, (start_lat, start_lon, end_lat, end_lon, departure_date_time,))
                 except ProgrammingError:
-                    return nb_carpoolings_route, []
+                    return nb_carpoolings_route, carpoolings_data
                 except Exception as e:
                     raise InternalServer(str(e))
                 carpoolings_data = curs.fetchall()
-
         return (nb_carpoolings_route,
                 [CarpoolingForRecap.to_self(carpooling) for carpooling in carpoolings_data])
 

--- a/src/database/repositories/driver_profile_repository.py
+++ b/src/database/repositories/driver_profile_repository.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from typing import Any
 
 from psycopg2 import ProgrammingError, errorcodes
 from psycopg2.errors import lookup
@@ -19,6 +18,7 @@ class DriverProfileRepositoryInterface(ABC):
     def get_driver(self,
                    driver_id: int) -> DriverProfileTable: ...
 
+
 class DriverProfileRepository(DriverProfileRepositoryInterface):
     POSTGRES_TABLE_NAME: str = "driver_profile"
 
@@ -31,12 +31,7 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
         """
 
         conducteur_profile: tuple
-        conn: Any
-        try:
-            conn = establishing_connection()
-        except InternalServer as e:
-            raise InternalServer(str(e))
-        else:
+        with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (user.id,))
@@ -44,10 +39,7 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
                     raise UniqueViolation(str(e))
                 except Exception as e:
                     raise InternalServer(str(e))
-                else:
-                    conducteur_profile = curs.fetchone()
-            conn.commit()
-            conn.close()
+                conducteur_profile = curs.fetchone()
         return DriverProfileTable.to_self(conducteur_profile)
 
     def get_driver(self,
@@ -56,13 +48,8 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
                     FROM carmate.{DriverProfileRepository.POSTGRES_TABLE_NAME} 
                     WHERE id=%s"""
 
-        conn: Any
         driver_data: tuple
-        try:
-            conn = establishing_connection()
-        except Exception as e:
-            raise InternalServer(str(e))
-        else:
+        with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (driver_id,))
@@ -71,7 +58,6 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
                     raise NotFound("driver not found")
                 except Exception as e:
                     raise InternalServer(str(e))
-            conn.close()
 
         if driver_data is None:
             raise NotFound("driver not found")
@@ -83,13 +69,8 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
                     FROM carmate.{DriverProfileRepository.POSTGRES_TABLE_NAME} 
                     WHERE user_id=%s"""
 
-        conn: Any
         driver_data: tuple
-        try:
-            conn = establishing_connection()
-        except Exception as e:
-            raise InternalServer(str(e))
-        else:
+        with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (user_id,))
@@ -98,7 +79,6 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
                     raise NotFound("driver not found")
                 except Exception as e:
                     raise InternalServer(str(e))
-            conn.close()
 
         if driver_data is None:
             raise NotFound("driver not found")

--- a/src/database/repositories/driver_profile_repository.py
+++ b/src/database/repositories/driver_profile_repository.py
@@ -25,7 +25,7 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
     def insert(self,
                user: UserTable) -> DriverProfileTable:
         query = f"""
-            INSERT INTO carmate.{DriverProfileRepository.POSTGRES_TABLE_NAME}(user_id)
+            INSERT INTO carmate.{self.POSTGRES_TABLE_NAME}(user_id)
             VALUES (%s)
             RETURNING id, "description", created_at, user_id
         """
@@ -44,20 +44,22 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
 
     def get_driver(self,
                    driver_id: int) -> DriverProfileTable:
-        query = f"""SELECT * 
-                    FROM carmate.{DriverProfileRepository.POSTGRES_TABLE_NAME} 
-                    WHERE id=%s"""
+        query = f"""
+            SELECT * 
+            FROM carmate.{self.POSTGRES_TABLE_NAME} 
+            WHERE id=%s
+        """
 
         driver_data: tuple
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (driver_id,))
-                    driver_data = curs.fetchone()
                 except ProgrammingError:
                     raise NotFound("driver not found")
                 except Exception as e:
                     raise InternalServer(str(e))
+                driver_data = curs.fetchone()
 
         if driver_data is None:
             raise NotFound("driver not found")
@@ -65,20 +67,22 @@ class DriverProfileRepository(DriverProfileRepositoryInterface):
 
     def get_driver_by_user_id(self,
                               user_id: int) -> DriverProfileTable:
-        query = f"""SELECT * 
-                    FROM carmate.{DriverProfileRepository.POSTGRES_TABLE_NAME} 
-                    WHERE user_id=%s"""
+        query = f"""
+            SELECT * 
+            FROM carmate.{self.POSTGRES_TABLE_NAME} 
+            WHERE user_id=%s
+        """
 
         driver_data: tuple
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (user_id,))
-                    driver_data = curs.fetchone()
                 except ProgrammingError:
                     raise NotFound("driver not found")
                 except Exception as e:
                     raise InternalServer(str(e))
+                driver_data = curs.fetchone()
 
         if driver_data is None:
             raise NotFound("driver not found")

--- a/src/database/repositories/license_repository.py
+++ b/src/database/repositories/license_repository.py
@@ -41,13 +41,15 @@ class LicenseRepository(LicenseRepositoryInterface):
                document: bytes,
                user: UserTable,
                document_type: str) -> LicenseTable:
-        query = f"""INSERT INTO carmate.{LicenseRepository.POSTGRES_TABLE_NAME}
-                    VALUES (DEFAULT, %s, %s, DEFAULT, DEFAULT, %s)
-                    RETURNING id, validation_status, published_at"""
+        query = f"""
+            INSERT INTO carmate.{self.POSTGRES_TABLE_NAME}
+            VALUES (DEFAULT, %s, %s, DEFAULT, DEFAULT, %s)
+            RETURNING id, validation_status, published_at
+        """
 
         id: int
-        published_at: datetime
         validation_status: str
+        published_at: datetime
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
@@ -57,19 +59,23 @@ class LicenseRepository(LicenseRepositoryInterface):
                 except Exception as e:
                     raise InternalServer(str(e))
                 id, validation_status, published_at = curs.fetchone()
-        return LicenseTable(id, document.read(), document_type, validation_status, published_at, user.id)
+        return LicenseTable(id, document, document_type, validation_status, published_at, user.id)
 
     def get_licenses_not_validated(self, page: int | None) -> Dict[str, Union[int, List[LicenseToValidateDTO]]]:
-        offset = (page - 1) * 30 if page is not None else 0
-        query = f"""SELECT ur.first_name, ur.last_name, ur.account_status, lr.published_at, lr.document_type, lr.id
-                    FROM carmate.{LicenseRepository.POSTGRES_TABLE_NAME} lr
-                    INNER JOIN carmate."{UserRepository.POSTGRES_TABLE_NAME}" ur ON lr.user_id = ur.id
-                    WHERE validation_status = 'Pending'
-                    LIMIT 30
-                    OFFSET {offset}"""
-        count_query = f"""SELECT COUNT(*)
-                    FROM carmate.{LicenseRepository.POSTGRES_TABLE_NAME}
-                    WHERE validation_status = 'Pending'"""
+        query = f"""
+            SELECT ur.first_name, ur.last_name, ur.account_status, lr.published_at, lr.document_type, lr.id
+            FROM carmate.{self.POSTGRES_TABLE_NAME} lr
+            INNER JOIN carmate."{UserRepository.POSTGRES_TABLE_NAME}" ur 
+                ON lr.user_id=ur.id
+            WHERE validation_status='Pending'
+            LIMIT 30
+            OFFSET {(page - 1) * 30 if page is not None else 0}
+        """
+        nb_documents_query = f"""
+            SELECT COUNT(*)
+            FROM carmate.{self.POSTGRES_TABLE_NAME}
+            WHERE validation_status='Pending'
+        """
 
         with establishing_connection() as conn:
             with conn.cursor() as curs:
@@ -78,21 +84,26 @@ class LicenseRepository(LicenseRepositoryInterface):
                 except Exception as e:
                     raise InternalServer(str(e))
                 license_rows = curs.fetchall()
+
                 try:
-                    curs.execute(count_query)
+                    curs.execute(nb_documents_query)
                 except Exception as e:
                     raise InternalServer(str(e))
-                count = curs.fetchone()
+                nb_documents = curs.fetchone()
+
         return {
-            "nb_documents": count,
+            "nb_documents": nb_documents,
             "items": [LicenseToValidateDTO(*tpl) for tpl in license_rows]
         }
 
     def get_license_not_validated(self, document_id: int) -> LicenseToValidate:
-        query = f"""SELECT ur.first_name, ur.last_name, ur.account_status, lr.published_at, lr.document_type, lr.license_img, lr.validation_status
-                    FROM carmate.{LicenseRepository.POSTGRES_TABLE_NAME} lr
-                    INNER JOIN carmate."{UserRepository.POSTGRES_TABLE_NAME}" ur ON lr.user_id = ur.id
-                    WHERE lr.id = %s"""
+        query = f"""
+            SELECT ur.first_name, ur.last_name, ur.account_status, lr.published_at, lr.document_type, lr.license_img, lr.validation_status
+            FROM carmate.{LicenseRepository.POSTGRES_TABLE_NAME} lr
+            INNER JOIN carmate."{UserRepository.POSTGRES_TABLE_NAME}" ur 
+                ON lr.user_id=ur.id
+            WHERE lr.id=%s
+        """
 
         with establishing_connection() as conn:
             with conn.cursor() as curs:
@@ -104,19 +115,20 @@ class LicenseRepository(LicenseRepositoryInterface):
                     raise NotFound("document not found")
                 except Exception as e:
                     raise InternalServer(str(e))
-
                 found_license = curs.fetchone()
-                if not found_license:
-                    raise NotFound("document not found")
 
+        if found_license is None:
+            raise NotFound("document not found")
         if found_license[6] != ValidationStatus.Pending.name:
             raise DocumentAlreadyChecked("document is already checked")
         return LicenseToValidate.tuple_to_self(found_license)
 
     def update_status(self, license_id: int, validation_status: str) -> None:
-        query = f"""UPDATE carmate.{LicenseRepository.POSTGRES_TABLE_NAME}
-                    SET validation_status=%s
-                    WHERE id=%s"""
+        query = f"""
+            UPDATE carmate.{LicenseRepository.POSTGRES_TABLE_NAME}
+            SET validation_status=%s
+            WHERE id=%s
+        """
 
         with establishing_connection() as conn:
             with conn.cursor() as curs:
@@ -126,39 +138,44 @@ class LicenseRepository(LicenseRepositoryInterface):
                     raise InvalidInputEnumValue(str(e))
                 except Exception as e:
                     raise InternalServer(str(e))
-
                 if curs.rowcount == 0:
                     raise NotFound("license not found, can't update")
 
     def get_next_license_id_to_validate(self) -> int:
-        query = f"""SELECT lr.id
-                    FROM carmate.{LicenseRepository.POSTGRES_TABLE_NAME} lr
-                    INNER JOIN carmate."{UserRepository.POSTGRES_TABLE_NAME}" ur ON lr.user_id = ur.id
-                    WHERE validation_status = 'Pending'
-                    LIMIT 1
-                    """
+        query = f"""
+            SELECT lr.id
+            FROM carmate.{LicenseRepository.POSTGRES_TABLE_NAME} lr
+            INNER JOIN carmate."{UserRepository.POSTGRES_TABLE_NAME}" ur 
+                ON lr.user_id = ur.id
+            WHERE validation_status = 'Pending'
+            LIMIT 1
+        """
 
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query)
-                    next_id = curs.fetchone()
                 except TypeError:
                     raise NotFound("No more licenses to validate")
                 except ProgrammingError:
                     raise NotFound("No more licenses to validate")
                 except Exception as e:
                     raise InternalServer(str(e))
+                next_id = curs.fetchone()
 
         if next_id is not None and len(next_id) > 0:
             return next_id[0]
         raise NotFound("No more licenses to validate")
 
     def get_license_by_user_id(self, user_id: int, document_type: str) -> LicenseTable:
-        query = f"""SELECT *
-                FROM carmate.{LicenseRepository.POSTGRES_TABLE_NAME} as lr
-                INNER JOIN carmate."{UserRepository.POSTGRES_TABLE_NAME}" as ur ON lr.user_id = ur.id
-                WHERE document_type = %s AND user_id = %s"""
+        query = f"""
+            SELECT *
+            FROM carmate.{LicenseRepository.POSTGRES_TABLE_NAME} AS lr
+            INNER JOIN carmate."{UserRepository.POSTGRES_TABLE_NAME}" AS ur 
+                ON lr.user_id=ur.id
+            WHERE document_type=%s 
+                AND user_id=%s
+        """
 
         license_table: tuple | None
         with establishing_connection() as conn:
@@ -173,5 +190,4 @@ class LicenseRepository(LicenseRepositoryInterface):
 
         if license_table is None:
             raise NotFound("License not found")
-
         return LicenseTable.to_self(license_table)

--- a/src/database/repositories/passenger_profile_repository.py
+++ b/src/database/repositories/passenger_profile_repository.py
@@ -24,9 +24,11 @@ class PassengerProfileRepository(PassengerProfileRepositoryInterface):
 
     def insert(self,
                user: UserTable) -> PassengerProfileTable:
-        query = f"""INSERT INTO carmate.{PassengerProfileRepository.POSTGRES_TABLE_NAME}(user_id)
-                    VALUES (%s)
-                    RETURNING id, "description", created_at, user_id"""
+        query = f"""
+            INSERT INTO carmate.{PassengerProfileRepository.POSTGRES_TABLE_NAME}(user_id)
+            VALUES (%s)
+            RETURNING id, "description", created_at, user_id
+        """
 
         passenger_profile: tuple
         with establishing_connection() as conn:
@@ -42,20 +44,22 @@ class PassengerProfileRepository(PassengerProfileRepositoryInterface):
 
     def get_passenger(self,
                       passenger_id: int) -> PassengerProfileTable:
-        query = f"""SELECT * 
-                    FROM carmate.{PassengerProfileRepository.POSTGRES_TABLE_NAME} 
-                    WHERE id=%s"""
+        query = f"""
+            SELECT * 
+            FROM carmate.{PassengerProfileRepository.POSTGRES_TABLE_NAME} 
+            WHERE id=%s
+        """
 
         passenger_data: tuple
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (passenger_id,))
-                    passenger_data = curs.fetchone()
                 except ProgrammingError:
                     raise NotFound("passenger not found")
                 except Exception as e:
                     raise InternalServer(str(e))
+                passenger_data = curs.fetchone()
 
         if passenger_data is None:
             raise NotFound("passenger not found")
@@ -72,11 +76,11 @@ class PassengerProfileRepository(PassengerProfileRepositoryInterface):
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (user_id,))
-                    passenger_data = curs.fetchone()
                 except ProgrammingError:
                     raise NotFound("passenger not found")
                 except Exception as e:
                     raise InternalServer(str(e))
+                passenger_data = curs.fetchone()
 
         if passenger_data is None:
             raise NotFound("passenger not found")

--- a/src/database/repositories/passenger_profile_repository.py
+++ b/src/database/repositories/passenger_profile_repository.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from typing import Any
 
 from psycopg2 import ProgrammingError, errorcodes
 from psycopg2.errors import lookup
@@ -12,11 +11,11 @@ from database.schemas import PassengerProfileTable, UserTable
 class PassengerProfileRepositoryInterface(ABC):
     def insert(self,
                user: UserTable) -> PassengerProfileTable: ...
-    
+
     def get_passenger_by_user_id(self,
                                  user_id: int) -> PassengerProfileTable: ...
-    
-    def get_passenger(self, 
+
+    def get_passenger(self,
                       passenger_id: int) -> PassengerProfileTable: ...
 
 
@@ -28,14 +27,9 @@ class PassengerProfileRepository(PassengerProfileRepositoryInterface):
         query = f"""INSERT INTO carmate.{PassengerProfileRepository.POSTGRES_TABLE_NAME}(user_id)
                     VALUES (%s)
                     RETURNING id, "description", created_at, user_id"""
-        
+
         passenger_profile: tuple
-        conn: Any
-        try:
-            conn = establishing_connection()
-        except InternalServer as e:
-            raise InternalServer(str(e))
-        else:
+        with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (user.id,))
@@ -43,25 +37,17 @@ class PassengerProfileRepository(PassengerProfileRepositoryInterface):
                     raise UniqueViolation(str(e))
                 except Exception as e:
                     raise InternalServer(str(e))
-                else:
-                    passenger_profile = curs.fetchone()
-            conn.commit()
-            conn.close()
+                passenger_profile = curs.fetchone()
         return PassengerProfileTable.to_self(passenger_profile)
-    
-    def get_passenger(self, 
+
+    def get_passenger(self,
                       passenger_id: int) -> PassengerProfileTable:
         query = f"""SELECT * 
                     FROM carmate.{PassengerProfileRepository.POSTGRES_TABLE_NAME} 
                     WHERE id=%s"""
 
-        conn: Any
         passenger_data: tuple
-        try:
-            conn = establishing_connection()
-        except Exception as e:
-            raise InternalServer(str(e))
-        else:
+        with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (passenger_id,))
@@ -70,12 +56,10 @@ class PassengerProfileRepository(PassengerProfileRepositoryInterface):
                     raise NotFound("passenger not found")
                 except Exception as e:
                     raise InternalServer(str(e))
-            conn.close()
 
         if passenger_data is None:
             raise NotFound("passenger not found")
         return PassengerProfileTable.to_self(passenger_data)
-
 
     def get_passenger_by_user_id(self,
                                  user_id: int) -> PassengerProfileTable:
@@ -83,13 +67,8 @@ class PassengerProfileRepository(PassengerProfileRepositoryInterface):
                     FROM carmate.{PassengerProfileRepository.POSTGRES_TABLE_NAME} 
                     WHERE user_id=%s"""
 
-        conn: Any
         passenger_data: tuple
-        try:
-            conn = establishing_connection()
-        except Exception as e:
-            raise InternalServer(str(e))
-        else:
+        with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (user_id,))
@@ -98,7 +77,6 @@ class PassengerProfileRepository(PassengerProfileRepositoryInterface):
                     raise NotFound("passenger not found")
                 except Exception as e:
                     raise InternalServer(str(e))
-            conn.close()
 
         if passenger_data is None:
             raise NotFound("passenger not found")

--- a/src/database/repositories/token_repository.py
+++ b/src/database/repositories/token_repository.py
@@ -12,26 +12,32 @@ from database.schemas import UserTable, TokenTable, DriverProfileTable
 
 
 class TokenRepositoryInterface(ABC):
-    @staticmethod
-    def insert(token: str, expiration: datetime, user: UserTable) -> TokenTable: ...
-    
-    @staticmethod
-    def get_expiration(token_hashed: bytes) -> datetime: ...
+    def insert(self,
+            token: str, 
+            expiration: datetime, 
+            user: UserTable) -> TokenTable: ...
 
-    @staticmethod
-    def get_user(token: bytes) -> UserTable: ...
+    def get_expiration(self,
+                       token_hashed: bytes) -> datetime: ...
+
+    def get_user(self,
+                 token: bytes) -> UserTable: ...
     
-    @staticmethod
-    def get_driver_profile(token: bytes) -> DriverProfileTable: ...
+    def get_driver_profile(self,
+                           token: bytes) -> DriverProfileTable: ...
 
 
 class TokenRepository(TokenRepositoryInterface):
     POSTGRES_TABLE_NAME: str = "token"
 
-    @staticmethod
-    def insert(token: str, expiration: datetime, user: UserTable) -> TokenTable:
-        query = f"""INSERT INTO carmate.{TokenRepository.POSTGRES_TABLE_NAME}
-                    VALUES (%s, %s, %s)"""
+    def insert(self,
+               token: str,
+               expiration: datetime,
+               user: UserTable) -> TokenTable:
+        query = f"""
+            INSERT INTO carmate.{self.POSTGRES_TABLE_NAME}
+            VALUES (%s, %s, %s)
+        """
 
         with establishing_connection() as conn:
             with conn.cursor() as curs:
@@ -43,71 +49,73 @@ class TokenRepository(TokenRepositoryInterface):
                     raise InternalServer(str(e))
         return TokenTable(token, expiration, user.id)
     
-    @staticmethod
-    def get_expiration(token_hashed: bytes) -> datetime:
-        query = f"""SELECT expire_at 
-                    FROM carmate.{TokenRepository.POSTGRES_TABLE_NAME}
-                    WHERE token=%s
-                    LIMIT 1"""
+    def get_expiration(self,
+                       token_hashed: bytes) -> datetime:
+        query = f"""
+            SELECT expire_at 
+            FROM carmate.{self.POSTGRES_TABLE_NAME}
+            WHERE token=%s
+            LIMIT 1
+        """
 
         expire_at: datetime
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (token_hashed,))
-                    expire_at = curs.fetchone()[0]
-                except TypeError:
-                    raise NotFound("token not found")
                 except ProgrammingError:
-                    raise NotFound("token not found")
-                except IndexError:
                     raise NotFound("token not found")
                 except Exception as e:
                     raise InternalServer(str(e))
-        return expire_at
+                expire_at = curs.fetchone()
+        
+        if expire_at is None:
+            raise NotFound("token not found")
+        return expire_at[0]
 
-    @staticmethod
-    def get_user(token: bytes) -> UserTable:
-        query = f"""SELECT usr.id, usr.first_name, usr.last_name, usr.email_address, NULL, usr.account_status, usr.created_at, usr.profile_picture
-                    FROM carmate."{UserRepository.POSTGRES_TABLE_NAME}" usr
-                    INNER JOIN carmate.{TokenRepository.POSTGRES_TABLE_NAME} tkn 
-                      ON usr.id = tkn.user_id 
-                    WHERE tkn.token=%s"""
+    def get_user(self,
+                 token: bytes) -> UserTable:
+        query = f"""
+            SELECT usr.id, usr.first_name, usr.last_name, usr.email_address, NULL, usr.account_status, usr.created_at, usr.profile_picture
+            FROM carmate."{UserRepository.POSTGRES_TABLE_NAME}" usr
+            INNER JOIN carmate.{self.POSTGRES_TABLE_NAME} tkn 
+                ON usr.id = tkn.user_id 
+            WHERE tkn.token=%s
+        """
 
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (token,))
-                    user = curs.fetchone()
                 except ProgrammingError:
-                    raise NotFound("token not found")
-                except IndexError:
                     raise NotFound("token not found")
                 except Exception as e:
                     raise InternalServer(str(e))
-        if not user:
+                user = curs.fetchone()
+    
+        if user is None:
             raise NotFound("token not found")
         return UserTable.to_self(user)
 
-    @staticmethod
-    def get_driver_profile(token: bytes) -> DriverProfileTable:
-        query = f"""SELECT driver.*
-                    FROM carmate.{TokenRepository.POSTGRES_TABLE_NAME} as tkn
-                    INNER JOIN carmate.{UserRepository.POSTGRES_TABLE_NAME} as usr ON tkn.user_id = usr.id
-                    Inner JOIN carmate.{DriverProfileRepository.POSTGRES_TABLE_NAME} as driver ON usr.id = driver.user_id
-                    WHERE tkn.token=%s"""
+    def get_driver_profile(self,
+                           token: bytes) -> DriverProfileTable:
+        query = f"""
+            SELECT driver.*
+            FROM carmate.{self.POSTGRES_TABLE_NAME} AS tkn
+            INNER JOIN carmate.{UserRepository.POSTGRES_TABLE_NAME} AS usr 
+                ON tkn.user_id = usr.id
+            Inner JOIN carmate.{DriverProfileRepository.POSTGRES_TABLE_NAME} AS driver 
+                ON usr.id = driver.user_id
+            WHERE tkn.token=%s
+        """
 
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (token,))
                 except ProgrammingError:
-                    raise NotFound("driver not found")
-                except IndexError:
                     raise NotFound("driver not found")
                 except Exception as e:
                     raise InternalServer(str(e))
                 driver_profile = curs.fetchone()
-
         return DriverProfileTable.to_self(driver_profile)
-

--- a/src/database/repositories/user_admin_repository.py
+++ b/src/database/repositories/user_admin_repository.py
@@ -1,29 +1,37 @@
 from abc import ABC
 
+from psycopg2 import ProgrammingError
+
 from database import establishing_connection
+from database.exceptions import InternalServer, NotFound
 
 
 class UserAdminRepositoryInterface(ABC):
-    @staticmethod
-    def is_admin(user_id: int) -> bool: ...
+    def is_admin(self,
+                user_id: int) -> bool: ...
 
 
 class UserAdminRepository(UserAdminRepositoryInterface):
     POSTGRES_TABLE_NAME: str = "user_admin"
-    @staticmethod
-    def is_admin(user_id: int) -> bool:
-        query = f"""SELECT EXISTS (
-                        SELECT 1 
-                        FROM carmate.{UserAdminRepository.POSTGRES_TABLE_NAME}
-                        WHERE user_id=%s
-                    ) as is_admin"""
+
+    def is_admin(self,
+                 user_id: int) -> bool:
+        query = f"""
+            SELECT EXISTS (
+                SELECT 1 
+                FROM carmate.{self.POSTGRES_TABLE_NAME}
+                WHERE user_id=%s
+            ) AS is_admin
+        """
 
         user_data: tuple
         with establishing_connection() as conn:
             with conn.cursor() as curs:
-                curs.execute(query, (user_id, ))
+                try:
+                    curs.execute(query, (user_id,))
+                except ProgrammingError:
+                    raise NotFound("user not found")
+                except Exception as e:
+                    raise InternalServer(str(e))
                 user_data = curs.fetchone()[0]
-
-        if not user_data:
-            return False
-        return True
+        return user_data is not None and bool(user_data)

--- a/src/database/repositories/user_admin_repository.py
+++ b/src/database/repositories/user_admin_repository.py
@@ -1,7 +1,6 @@
 from abc import ABC
-from typing import Any
 
-from database import establishing_connection, InternalServer
+from database import establishing_connection
 
 
 class UserAdminRepositoryInterface(ABC):
@@ -19,18 +18,12 @@ class UserAdminRepository(UserAdminRepositoryInterface):
                         WHERE user_id=%s
                     ) as is_admin"""
 
-        conn: Any
         user_data: tuple
-        try:
-            conn = establishing_connection()
-        except Exception as e:
-            raise InternalServer(str(e))
-        else:
+        with establishing_connection() as conn:
             with conn.cursor() as curs:
                 curs.execute(query, (user_id, ))
                 user_data = curs.fetchone()[0]
 
-            conn.close()
-            if not user_data:
-                return False
+        if not user_data:
+            return False
         return True

--- a/src/database/repositories/user_banned_repository.py
+++ b/src/database/repositories/user_banned_repository.py
@@ -1,8 +1,7 @@
 from abc import ABC
-from typing import Any, List
+from typing import List
 
 from database import establishing_connection
-from database.exceptions import InternalServer
 
 
 class UserBannedRepositoryInterface(ABC):
@@ -24,18 +23,12 @@ class UserBannedRepository(UserBannedRepositoryInterface):
                 WHERE user_id = %s
             ) as is_banned"""
 
-        conn: Any
         user_data: tuple
-        try:
-            conn = establishing_connection()
-        except Exception as e:
-            raise InternalServer(str(e))
-        else:
+        with establishing_connection() as conn:
             with conn.cursor() as curs:
                 curs.execute(query, (user_id, ))
                 user_data = curs.fetchone()[0]
 
-            conn.close()
-            if not user_data:
-                return False
+        if not user_data:
+            return False
         return True

--- a/src/database/repositories/user_repository.py
+++ b/src/database/repositories/user_repository.py
@@ -12,25 +12,29 @@ from database.schemas import UserTable
 
 
 class UserRepositoryInterface(ABC):
-    @staticmethod
-    def insert(credential: CredentialDTO, account_status: AccountStatus) -> UserTable: ...
+    def insert(self,
+               credential: CredentialDTO,
+               account_status: AccountStatus) -> UserTable: ...
 
-    @staticmethod
-    def get_user_by_email(email: str) -> UserTable: ...
+    def get_user_by_email(self,
+                          email: str) -> UserTable: ...
 
-    @staticmethod
-    def get_user_by_id(id: int) -> UserTable: ...
+    def get_user_by_id(self,
+                       id: int) -> UserTable: ...
 
 
 class UserRepository(UserRepositoryInterface):
     POSTGRES_TABLE_NAME: str = "user"
 
-    @staticmethod
-    def insert(credential: CredentialDTO, account_status: AccountStatus) -> UserTable:
+    def insert(self,
+               credential: CredentialDTO, 
+               account_status: AccountStatus) -> UserTable:
         first_name, last_name, email_address, password = credential.to_json().values()
-        query: str = f"""INSERT INTO carmate.{UserRepository.POSTGRES_TABLE_NAME}(first_name, last_name, email_address, password, account_status)
-                         VALUES (%s, %s, %s, %s, %s) 
-                         RETURNING id, first_name, last_name, email_address, password, account_status, created_at, profile_picture"""
+        query: str = f"""
+            INSERT INTO carmate.{self.POSTGRES_TABLE_NAME}(first_name, last_name, email_address, password, account_status)
+            VALUES (%s, %s, %s, %s, %s) 
+            RETURNING id, first_name, last_name, email_address, password, account_status, created_at, profile_picture
+        """
 
         user: tuple
         with establishing_connection() as conn:
@@ -45,36 +49,45 @@ class UserRepository(UserRepositoryInterface):
                 user = curs.fetchone()
         return UserTable.to_self(user)
 
-    @staticmethod
-    def get_user_by_email(email: str) -> UserTable:
-        query = f"""SELECT * FROM carmate.{UserRepository.POSTGRES_TABLE_NAME} 
-                    WHERE email_address=%s"""
+    def get_user_by_email(self,
+                          email: str) -> UserTable:
+        query = f"""
+            SELECT * FROM carmate.{self.POSTGRES_TABLE_NAME} 
+            WHERE email_address=%s
+        """
 
         user_data: tuple
         with establishing_connection() as conn:
             with conn.cursor() as curs:
-                curs.execute(query, (email,))
+                try:
+                    curs.execute(query, (email,))
+                except ProgrammingError:
+                    raise NotFound("user not found")
+                except Exception as e:
+                    raise InternalServer(str(e))
                 user_data = curs.fetchone()
 
-        if not user_data:
+        if user_data is None:
             raise NotFound("user not found")
         return UserTable.to_self(user_data)
 
-    @staticmethod
-    def get_user_by_id(id: int) -> UserTable:
-        query = f"""SELECT * FROM carmate.{UserRepository.POSTGRES_TABLE_NAME} 
-                    WHERE id=%s"""
+    def get_user_by_id(self,
+                       id: int) -> UserTable:
+        query = f"""
+            SELECT * FROM carmate.{self.POSTGRES_TABLE_NAME} 
+            WHERE id=%s
+        """
 
         user_data: tuple
         with establishing_connection() as conn:
             with conn.cursor() as curs:
                 try:
                     curs.execute(query, (id,))
-                    user_data = curs.fetchone()
                 except ProgrammingError:
                     raise NotFound("user not found")
                 except Exception as e:
                     raise InternalServer(str(e))
+                user_data = curs.fetchone()
 
         if user_data is None:
             raise NotFound("user not found")


### PR DESCRIPTION
# Why ?
Because, a `before_request` exist for check is the database is available and throw `503` if the database is down